### PR TITLE
Treat static property as static property

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -62,7 +62,7 @@ public function __get ( $name ) {
   switch ( $name ) {
 
     case "tempDir":
-      return $this->TEMP_DIR;
+      return static::$TEMP_DIR;
 
     case "autoloadDirs":
       return $this->autoloadDirs;
@@ -146,8 +146,8 @@ public function configure ( $configFile=null ) {
   # Use full, real paths
   if ( is_string( $this->ROUTES_INI ) && $this->ROUTES_INI ) {
     $this->ROUTES_INI = \Phi\Tools::pathTo( $this->ROUTES_INI );
-    $this->TEMP_DIR = sys_get_temp_dir() . $this->TEMP_DIR;
-    if (! is_dir( $this->TEMP_DIR ) ) mkdir( $this->TEMP_DIR, 0777, true );
+    static::$TEMP_DIR = sys_get_temp_dir() . static::$TEMP_DIR;
+    if (! is_dir( static::$TEMP_DIR ) ) mkdir( static::$TEMP_DIR, 0777, true );
   }
 
 }


### PR DESCRIPTION
We can either drop the term `static` from the line `public static $TEMP_DIR  = "/com.lakehawksolutions.Phi";`
or else update references to `$this->TEMP_DIR` to become `static::$TEMP_DIR` (or, perhaps, `self::$TEMP_DIR`).
That's what this PR is for: Rewriting `$this->TEMP_DIR` to avoid filling error logs with warnings like 
```
Accessing static property Phi\App::$TEMP_DIR as non static
```
If you would rather change one line, just set `public static $TEMP_DIR` back to `public $TEMP_DIR` (no static).

I usually prefer `static::` to `self::` so that child classes are free to access/modify it. (I especially prefer `static::` for functions.)