### PR TITLE
Minor improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "lacockj/phi",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "A fast, easy-to-use micro-framework balancing speed, convenience, and security.",
     "license": "GPL-3.0-or-later",
     "require": {

--- a/src/Database.php
+++ b/src/Database.php
@@ -117,7 +117,11 @@ public function pq ( $sql, $params=null, $types=null ) {
     if ( is_scalar( $params ) ) $params = array( $params ); # Recast single, scalar param as single-element array. #
     if (! $types) $types = str_repeat('s', count($params)); # Default to string parameters. #
     $bind_params = array();
-    foreach ( $params as &$p ) $bind_params[] = &$p; # Bound parameters must be passed by reference. #
+    foreach ( $params as &$p ) {
+      if (!is_scalar($p)) $p = json_encode($p);
+      $bind_params[] = &$p; # Bound parameters must be passed by reference. #
+    }
+    unset($p);
     array_unshift( $bind_params, $types );
     if (! call_user_func_array( array($stmt, "bind_param"), $bind_params )) {
       $this->errors[] = array(

--- a/src/Response.php
+++ b/src/Response.php
@@ -67,6 +67,7 @@ public static function allow_cache ( $mtime, $etag="", $maxAge=0, $private=false
   $privacy = ($private) ? 'private' : 'public';
   header( "Cache-Control: $privacy, max-age=$maxAge" );
   header( "Last-Modified: ".gmdate("D, d M Y H:i:s", $mtime)." GMT");
+  header( "Access-Control-Expose-Headers: ETag" );
   header( "ETag: $etag" );
 }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -63,6 +63,10 @@ public static function allow_origin ( $origin ) {
 
 # Cache-Control Methods #
 
+public static function no_cache () {
+  header('Cache-Control: no-store, no-cache, must-revalidate');
+}
+
 public static function allow_cache ( $mtime, $etag="", $maxAge=0, $private=false ) {
   $privacy = ($private) ? 'private' : 'public';
   header( "Cache-Control: $privacy, max-age=$maxAge" );

--- a/src/Response.php
+++ b/src/Response.php
@@ -56,7 +56,7 @@ public static function content_ndjson () {
 
 public static function allow_origin ( $origin ) {
   header( "Access-Control-Allow-Origin: $origin" );
-  header( "Access-Control-Allow-Headers: Authorization, Content-Type, X-Api-Key, X-Guest-Key" );
+  header( "Access-Control-Allow-Headers: Authorization, Content-Type, If-Modified-Since, If-None-Match, X-Api-Key, X-Guest-Key" );
   header( "Access-Control-Allow-Credentials: true" );
 }
 


### PR DESCRIPTION
A little work with allowed cross-origin headers, automatically setting no-cache headers, and JSON encoding non-scalar query parameters.